### PR TITLE
feat: Add window dragging support for borderless window

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,40 +1,47 @@
 import os
 import json
+import ctypes
 import logging
-from . import __mail__
+from . import utils
 import customtkinter
+from . import __mail__
 from typing import Any
+from .load_icons import *
+from dotenv import load_dotenv
 from .__server__ import SERVER
+from hPyT import title_bar, get_accent_color
+from pywinstyles import apply_style, set_opacity
 
 CONSTANTS: dict[str, dict[str, Any]] = {
-    
-    'WEBSITES' : {
-
-        'GITHUB_REPOSITORY' : 'https://github.com/ViratiAkiraNandhanReddy/Bank-With-High-Functionalities',
-        'PROJECT_WEBSITE' : 'https://viratiakiranandhanreddy.github.io/Bank-With-High-Functionalities/',
-
+    "WEBSITES": {
+        "GITHUB_REPOSITORY": "https://github.com/ViratiAkiraNandhanReddy/Bank-With-High-Functionalities",
+        "PROJECT_WEBSITE": "https://viratiakiranandhanreddy.github.io/Bank-With-High-Functionalities/",
     },
-
-    'SOCIALS' : {
-
-        'GITHUB' : 'https://github.com/ViratiAkiraNandhanReddy',
-        'INSTAGRAM' : 'https://www.instagram.com/viratiakiranandhanreddy',
-        'TWITTER' : 'https://twitter.com/akiranandhan_',
-        'LINKEDIN' : 'https://www.linkedin.com/in/viratiakiranandhanreddy',
-        'YOUTUBE' : 'https://www.youtube.com/@ViratiAkiraNandhanReddy',
-        
+    "SOCIALS": {
+        "GITHUB": "https://github.com/ViratiAkiraNandhanReddy",
+        "INSTAGRAM": "https://www.instagram.com/viratiakiranandhanreddy",
+        "TWITTER": "https://twitter.com/akiranandhan_",
+        "LINKEDIN": "https://www.linkedin.com/in/viratiakiranandhanreddy",
+        "YOUTUBE": "https://www.youtube.com/@ViratiAkiraNandhanReddy",
     },
-
-    
 }
 
-DIR_PATH = str(os.environ.get('LOCALAPPDATA')) + r'\Bank-With-High-Functionalities'
+DIR_PATH: str = str(os.environ.get("LOCALAPPDATA")) + r"\Bank-With-High-Functionalities"
 
 try:
 
-    with open(fr'{DIR_PATH}\database\json\administrative files\config.json','r') as config:
+    with open(rf"{DIR_PATH}\database\config.json", "r") as config:
         CONFIGURATION_JSON: dict[str, Any] = json.load(config)
 
 except FileNotFoundError, json.JSONDecodeError:
 
     CONFIGURATION_JSON = {}
+
+load_dotenv(rf"{DIR_PATH}\.env")
+
+
+def move_tk_with_no_titlebar_winos_native_ctypes(event, window: customtkinter.CTk):
+
+    hwnd = ctypes.windll.user32.GetParent(window.winfo_id())
+    ctypes.windll.user32.ReleaseCapture()
+    ctypes.windll.user32.PostMessageW(hwnd, 0xA1, 2, 0)

--- a/src/login.py
+++ b/src/login.py
@@ -39,6 +39,13 @@ class login_interface:
             apply_style(self.window, "transparent")
             title_bar.hide(self.window, no_span=True)
 
+            self.window.bind(
+                "<Button-1>",
+                lambda event: move_tk_with_no_titlebar_winos_native_ctypes(
+                    event, self.window
+                ),
+            )
+
             self.window.after(600, self.show_login_rtl)
 
             # --- Login Screen Configuration --- #


### PR DESCRIPTION
## ✨ Add window dragging support for borderless (hPyT) window

### Summary

This PR restores native-like window movement after removing the OS title bar using `hPyT`.

Since the application uses a borderless window, the default draggable caption area is lost.
This change introduces a custom Win32 drag handler so users can move the window by dragging a designated UI region (e.g., header or background).

---

### Problem

* Title bar removed via `hPyT`
* No native draggable area
* Window cannot be repositioned

---

### Solution

* Implement Win32 move message (`WM_NCLBUTTONDOWN`, `HTCAPTION`)
* Trigger on mouse press in draggable region
* Apply to root/header frame
* Preserve acrylic / borderless styling compatibility

---

### Result

* Window can be dragged smoothly
* Behavior matches native Windows caption drag
* Works with custom UI and acrylic effects

---

### Checklist

* [x] Create reusable drag helper
* [x] Bind to header/root frame
* [x] Test with acrylic enabled
* [x] Verify behavior when window unfocused

---

### Notes

Required when using borderless windows via `hPyT`, as native OS movement is removed with the title bar.

Closes #8 
