### PR TITLE
Hotfix: Resolve Circular Imports in Database Provider Modules - (uuids)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,8 +8,8 @@ import customtkinter
 from .assets import *
 from .__mail__ import *
 from dotenv import load_dotenv
+from .__server__ import SERVER
 from typing import Any, Callable
-from .__server__ import SERVER, _uuids
 from hPyT import title_bar, get_accent_color
 from pywinstyles import apply_style, set_opacity
 

--- a/src/__server__/__init__.py
+++ b/src/__server__/__init__.py
@@ -1,33 +1,9 @@
 import json
-import uuid
 import logging
 from ..utils import root
 from ._json import SERVER as JSONServer
 from ._mysql import SERVER as MySQLServer
 from ._sqlite3 import SERVER as SQLite3Server
-
-
-class _uuids:
-
-    UUID_NAMESPACE_BWHF = uuid.UUID("71da99dc-ce4e-575e-a319-3083e9265046")
-    # pre-generated using:
-    # uuid.uuid5(
-    #     uuid.NAMESPACE_URL,
-    #     "https://viratiakiranandhanreddy.github.io/Bank-With-High-Functionalities/",
-    # )
-
-    @classmethod
-    def generate_uuid5(cls, name: str) -> str:
-        return str(uuid.uuid5(cls.UUID_NAMESPACE_BWHF, name))
-
-    @classmethod
-    def validate_uuid5(cls, uuid_to_validate: str) -> bool:
-        try:
-            uuid_obj = uuid.UUID(uuid_to_validate, version=5)
-            return True
-        except ValueError:
-            return False
-
 
 try:
 
@@ -49,4 +25,4 @@ match CONFIGURATION_JSON.get("DATABASE TYPE"):
     case "SQLite3":
         SERVER = SQLite3Server
 
-__all__ = ["SERVER", "_uuids"]
+__all__ = ["SERVER"]

--- a/src/__server__/__init__.py
+++ b/src/__server__/__init__.py
@@ -1,9 +1,6 @@
 import json
 import logging
 from ..utils import root
-from ._json import SERVER as JSONServer
-from ._mysql import SERVER as MySQLServer
-from ._sqlite3 import SERVER as SQLite3Server
 
 try:
 
@@ -19,10 +16,21 @@ except FileNotFoundError, json.JSONDecodeError:
 match CONFIGURATION_JSON.get("DATABASE TYPE"):
 
     case "JSON":
+
+        from ._json import SERVER as JSONServer
+
         SERVER = JSONServer
+
     case "MySQL":
+
+        from ._mysql import SERVER as MySQLServer
+
         SERVER = MySQLServer
+
     case "SQLite3":
+
+        from ._sqlite3 import SERVER as SQLite3Server
+
         SERVER = SQLite3Server
 
 __all__ = ["SERVER"]

--- a/src/__server__/_json/authentication.py
+++ b/src/__server__/_json/authentication.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from CaesarCipher import Encryption
 from ..__base__ import UserAuthenticationBase, AdminAuthenticationBase
 

--- a/src/__server__/_json/lookup.py
+++ b/src/__server__/_json/lookup.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ..__base__ import UserLookupBase, AdminLookupBase
 
 

--- a/src/__server__/_json/management.py
+++ b/src/__server__/_json/management.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from CaesarCipher import Encryption
 from ..__base__ import UserManagementBase, AdminManagementBase
 

--- a/src/__server__/_mysql/authentication.py
+++ b/src/__server__/_mysql/authentication.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ._connection import connection
 from CaesarCipher import Encryption
 from ..__base__ import UserAuthenticationBase, AdminAuthenticationBase

--- a/src/__server__/_mysql/lookup.py
+++ b/src/__server__/_mysql/lookup.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ._connection import connection
 from ..__base__ import UserLookupBase, AdminLookupBase
 

--- a/src/__server__/_mysql/management.py
+++ b/src/__server__/_mysql/management.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ._connection import connection
 from CaesarCipher import Encryption
 from ..__base__ import UserManagementBase, AdminManagementBase

--- a/src/__server__/_sqlite3/authentication.py
+++ b/src/__server__/_sqlite3/authentication.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ._connection import connection
 from CaesarCipher import Encryption
 from ..__base__ import UserAuthenticationBase, AdminAuthenticationBase

--- a/src/__server__/_sqlite3/lookup.py
+++ b/src/__server__/_sqlite3/lookup.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ._connection import connection
 from ..__base__ import UserLookupBase, AdminLookupBase
 

--- a/src/__server__/_sqlite3/management.py
+++ b/src/__server__/_sqlite3/management.py
@@ -1,4 +1,4 @@
-from ... import _uuids
+from .._uuids import _uuids
 from ._connection import connection
 from CaesarCipher import Encryption
 from ..__base__ import UserManagementBase, AdminManagementBase

--- a/src/__server__/_uuids.py
+++ b/src/__server__/_uuids.py
@@ -1,0 +1,3 @@
+class _uuids:
+
+    pass

--- a/src/__server__/_uuids.py
+++ b/src/__server__/_uuids.py
@@ -1,3 +1,23 @@
+import uuid
+
+
 class _uuids:
 
-    pass
+    UUID_NAMESPACE_BWHF = uuid.UUID("71da99dc-ce4e-575e-a319-3083e9265046")
+    # pre-generated using:
+    # uuid.uuid5(
+    #     uuid.NAMESPACE_URL,
+    #     "https://viratiakiranandhanreddy.github.io/Bank-With-High-Functionalities/",
+    # )
+
+    @classmethod
+    def generate_uuid5(cls, name: str) -> str:
+        return str(uuid.uuid5(cls.UUID_NAMESPACE_BWHF, name))
+
+    @classmethod
+    def validate_uuid5(cls, uuid_to_validate: str) -> bool:
+        try:
+            uuid_obj = uuid.UUID(uuid_to_validate, version=5)
+            return True
+        except ValueError:
+            return False


### PR DESCRIPTION
## Summary ( Closes #58 )

Fix circular import issues in the database provider architecture by introducing a dedicated internal UUID utility module.

During the provider refactor, shared utilities such as UUID validation were imported via relative package paths (e.g. `from ... import _uuids`). This created circular import dependencies when `__server__/__init__.py` initialized provider modules.

This PR resolves the issue by moving UUID utilities into a standalone internal module and updating all provider imports accordingly.

## Changes

### Added Internal UUID Module

Introduced a dedicated internal utility module:

```text
__server__/_uuids.py
```

This module centralizes UUID-related utilities such as validation and removes dependency on package-level imports during initialization.

### Updated Provider Imports

Replaced problematic relative imports such as:

```python
from ... import _uuids
```

with:

```python
from __server__._uuids import _uuids
```

(or equivalent usage depending on implementation)

This breaks the circular dependency chain between provider modules and package initialization.

### Stabilized Package Initialization

Ensured that:

* `__server__/__init__.py` can safely import provider backends
* Provider modules no longer trigger recursive imports
* Shared utilities are imported independently of provider initialization

## Impact

* Eliminates circular import errors during package initialization
* Improves module dependency clarity
* Isolates shared utilities into a stable internal layer
* Ensures consistent and safe provider loadin

## Out of Scope

* Provider logic changes
* Authentication / lookup / management / schema modifications
* Database implementation changes
* Architecture redesign
* Performance optimizations

## Notes

This is a structural fix only. No backend behavior or API contracts were modified.
