### PR TITLE
refactor(server): migrate callers to the new provider API

### DIFF
--- a/src/sign_in/__init__.py
+++ b/src/sign_in/__init__.py
@@ -774,11 +774,7 @@ class sign_in_interface:
 
             elif (username and password) and (
                 (not SERVER.lookup.user.exists(username))
-                or (
-                    not SERVER.authentication.user.password(
-                        username, password
-                    )
-                )
+                or (not SERVER.authentication.user.password(username, password))
             ):  # username: true (not exists) -- password: true --[or]-- username: true (exists) -- password: true (wrong)
 
                 self.container_frame__username_sign_in.configure(border_color="#FF0000")
@@ -1046,7 +1042,7 @@ class sign_in_interface:
 
                     try:
 
-                        is_password_changed = SERVER.accountactions().change_password(
+                        is_password_changed = SERVER.management.user.change_password(
                             username_at_reset_password, new_password
                         )
 

--- a/src/sign_in/__init__.py
+++ b/src/sign_in/__init__.py
@@ -710,7 +710,7 @@ class sign_in_interface:
 
                 try:
 
-                    if SERVER.traversal().is_user_exists(username):
+                    if SERVER.lookup.user.exists(username):
 
                         self.window.withdraw()
                         dashboard_window = dashboard_interface.dashboard(
@@ -773,7 +773,7 @@ class sign_in_interface:
                 return
 
             elif (username and password) and (
-                (not SERVER.traversal().is_user_exists(username))
+                (not SERVER.lookup.user.exists(username))
                 or (
                     not SERVER.authentication().authenticate_password(
                         username, password
@@ -1177,7 +1177,7 @@ class sign_in_interface:
 
             elif (
                 username_at_reset_password
-                and not SERVER.traversal().is_user_exists(username_at_reset_password)
+                and not SERVER.lookup.user.exists(username_at_reset_password)
             ) and user_security_code_at_reset_password:  # username: true (not exists) -- password: true
                 Username_Exists_Error = customtkinter.CTkLabel(
                     self.frame__reset_password,

--- a/src/sign_in/__init__.py
+++ b/src/sign_in/__init__.py
@@ -775,7 +775,7 @@ class sign_in_interface:
             elif (username and password) and (
                 (not SERVER.lookup.user.exists(username))
                 or (
-                    not SERVER.authentication().authenticate_password(
+                    not SERVER.authentication.user.password(
                         username, password
                     )
                 )
@@ -1212,7 +1212,7 @@ class sign_in_interface:
                 auth__password_error.after(2000, auth__password_error.destroy)
 
             elif username_at_reset_password and (
-                not SERVER.authentication().authenticate_backup_code(
+                not SERVER.authentication.user.backup_code(
                     username_at_reset_password, user_security_code_at_reset_password
                 )
             ):  # username: true -- code: true (wrong)

--- a/src/sign_in/more_actions.py
+++ b/src/sign_in/more_actions.py
@@ -1267,7 +1267,7 @@ your administrator account.""",
                         return
 
                     elif (username and email_address) and (
-                        (not SERVER.traversal().is_admin_exists(username))
+                        (not SERVER.lookup.admin.exists(username))
                         or (
                             not SERVER.authentication().authenticate_admin_email_address(
                                 username, email_address
@@ -1609,7 +1609,7 @@ to continue secure recovery verification.""",
                         return
 
                     elif (username and backup_code) and (
-                        (not SERVER.traversal().is_admin_exists(username))
+                        (not SERVER.lookup.admin.exists(username))
                         or (
                             not SERVER.authentication().authenticate_admin_backup_code(
                                 username, backup_code
@@ -2030,7 +2030,7 @@ backup recovery code linked to your account.""",
                 return
 
             elif (admin_username and admin_password) and (
-                (not SERVER.traversal().is_admin_exists(admin_username))
+                (not SERVER.lookup.admin.exists(admin_username))
                 or (
                     not SERVER.authentication().authenticate_admin(
                         admin_username, admin_password

--- a/src/sign_in/more_actions.py
+++ b/src/sign_in/more_actions.py
@@ -463,10 +463,8 @@ the password reset process is completed.""",
 
                     else:
 
-                        is_password_changed = (
-                            SERVER.accountactions().change_admin_password(
-                                username, new_password
-                            )
+                        is_password_changed = SERVER.management.admin.change_password(
+                            username, new_password
                         )
 
                         if is_password_changed:

--- a/src/sign_in/more_actions.py
+++ b/src/sign_in/more_actions.py
@@ -1269,7 +1269,7 @@ your administrator account.""",
                     elif (username and email_address) and (
                         (not SERVER.lookup.admin.exists(username))
                         or (
-                            not SERVER.authentication().authenticate_admin_email_address(
+                            not SERVER.authentication.admin.email_address(
                                 username, email_address
                             )
                         )
@@ -1611,7 +1611,7 @@ to continue secure recovery verification.""",
                     elif (username and backup_code) and (
                         (not SERVER.lookup.admin.exists(username))
                         or (
-                            not SERVER.authentication().authenticate_admin_backup_code(
+                            not SERVER.authentication.admin.backup_code(
                                 username, backup_code
                             )
                         )
@@ -2032,7 +2032,7 @@ backup recovery code linked to your account.""",
             elif (admin_username and admin_password) and (
                 (not SERVER.lookup.admin.exists(admin_username))
                 or (
-                    not SERVER.authentication().authenticate_admin(
+                    not SERVER.authentication.admin.password(
                         admin_username, admin_password
                     )
                 )


### PR DESCRIPTION
## Summary ( Closes #61 )

Migrate database query engine consumers to the new provider-based `SERVER` API.

This PR updates existing call sites to use the standardized provider interface introduced by the database provider architecture. The migration preserves existing behavior while replacing legacy API usage with the new modular interface.

No database logic or provider implementations have been modified.

## Changes

### Updated Database API Consumers

Migrated project call sites to use the new provider interface.

Examples include:

```python
SERVER.authentication.user.password(...)
SERVER.authentication.admin.password(...)

SERVER.lookup.user.exists(...)
SERVER.lookup.admin.exists(...)

SERVER.management.user.change_password(...)
SERVER.management.admin.change_password(...)

SERVER.schema.user.create()
SERVER.schema.admin.create()
SERVER.schema.transaction.create()
```

### Replaced Legacy API Usage

Removed references to the legacy database API where applicable and updated callers to use the standardized provider structure.

The migration is limited to API usage only and does not alter application behavior.

## Impact

This PR:

* Completes the migration of database API consumers to the new provider architecture
* Standardizes database interactions throughout the project
* Improves consistency and maintainability
* Aligns all callers with the modular backend design

## Out of Scope

* Provider implementation changes
* SQLite3, MySQL, or JSON backend logic
* Database optimizations
* API redesign
* New features

## Notes

This PR updates only the callers of the database query engine. No functional changes have been introduced, and existing behavior is preserved.
