### PR TITLE
Implement balance display and refresh support for dashboard

### DIFF
--- a/src/__server__/__base__/lookup.py
+++ b/src/__server__/__base__/lookup.py
@@ -9,6 +9,12 @@ class UserLookupBase(ABC):
 
         pass
 
+    @classmethod
+    @abstractmethod
+    def balance(cls, username_or_uuid: str) -> float:
+
+        pass
+
 
 class AdminLookupBase(ABC):
 

--- a/src/__server__/_sqlite3/lookup.py
+++ b/src/__server__/_sqlite3/lookup.py
@@ -30,6 +30,29 @@ class UserLookup(UserLookupBase):
 
         return cursor.fetchone() is not None
 
+    @classmethod
+    def balance(cls, username_or_uuid) -> float:
+
+        if _uuids.validate_uuid5(username_or_uuid):
+
+            cursor.execute(
+                """
+                SELECT balance FROM USERS WHERE UUID = ?
+                """,
+                (username_or_uuid,),
+            )
+
+            return cursor.fetchone()[0]
+
+        cursor.execute(
+            """
+            SELECT balance FROM USERS WHERE USERNAME = ?
+            """,
+            (username_or_uuid,),
+        )
+
+        return cursor.fetchone()[0]
+
 
 class AdminLookup(AdminLookupBase):
 

--- a/src/__server__/_sqlite3/lookup.py
+++ b/src/__server__/_sqlite3/lookup.py
@@ -42,7 +42,8 @@ class UserLookup(UserLookupBase):
                 (username_or_uuid,),
             )
 
-            return cursor.fetchone()[0]
+            row = cursor.fetchone()
+            return row[0] if row is not None else 0.0
 
         cursor.execute(
             """
@@ -51,7 +52,8 @@ class UserLookup(UserLookupBase):
             (username_or_uuid,),
         )
 
-        return cursor.fetchone()[0]
+        row = cursor.fetchone()
+        return row[0] if row is not None else 0.0
 
 
 class AdminLookup(AdminLookupBase):

--- a/src/__server__/_sqlite3/schema.py
+++ b/src/__server__/_sqlite3/schema.py
@@ -35,7 +35,8 @@ class UserSchema(UserSchemaBase):
             PASSWORD TEXT NOT NULL,
             EMAIL TEXT,
             BACKUP_CODE TEXT NOT NULL,
-            CREATED_AT TIMESTAMP DEFAULT CURRENT_TIMESTAMP)
+            CREATED_AT TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            BALANCE REAL DEFAULT 0.0)
             """)
 
         connection.commit()

--- a/src/dashboard/tiles/balance.py
+++ b/src/dashboard/tiles/balance.py
@@ -1,4 +1,4 @@
-from ... import customtkinter
+from ... import customtkinter, SERVER
 
 
 class balance:
@@ -9,3 +9,17 @@ class balance:
             parent_frame, width=500, height=50, fg_color="#0a0a0a"
         )
         self.frame__balance.place(x=10, y=50)
+
+        self.label__balance: customtkinter.CTkLabel = customtkinter.CTkLabel(
+            self.frame__balance,
+            text=f"$ {SERVER.lookup.user.balance(username):,.2f}",
+            width=480,
+            height=50,
+            text_color="#FFFFFF",
+            font=("Roboto", 18),
+        )
+        self.label__balance.place(x=10, y=0)
+
+        self.refresh = lambda: self.label__balance.configure(
+            text=f"$ {SERVER.lookup.user.balance(username):,.2f}"
+        )

--- a/src/dashboard/tiles/balance.py
+++ b/src/dashboard/tiles/balance.py
@@ -10,9 +10,11 @@ class balance:
         )
         self.frame__balance.place(x=10, y=50)
 
+        self.username = username
+
         self.label__balance: customtkinter.CTkLabel = customtkinter.CTkLabel(
             self.frame__balance,
-            text=f"$ {SERVER.lookup.user.balance(username):,.2f}",
+            text=f"$ {SERVER.lookup.user.balance(self.username):,.2f}",
             width=480,
             height=50,
             text_color="#FFFFFF",
@@ -20,6 +22,8 @@ class balance:
         )
         self.label__balance.place(x=10, y=0)
 
-        self.refresh = lambda: self.label__balance.configure(
-            text=f"$ {SERVER.lookup.user.balance(username):,.2f}"
+    def refresh(self) -> None:
+
+        self.label__balance.configure(
+            text=f"$ {SERVER.lookup.user.balance(self.username):,.2f}"
         )


### PR DESCRIPTION
## Summary ( Closes #74 )

Implements balance display functionality for the dashboard's existing Balance Frame and introduces a reusable refresh mechanism for keeping the displayed balance synchronized with the latest account data.

To support this functionality, a new balance lookup method is added to the provider interface and implemented for the SQLite backend. The user schema is also updated to include a default account balance for newly created users.

## Changes

### Dashboard

* Display the authenticated user's current account balance in the Balance Frame
* Add a reusable `refresh()` interface to update the displayed balance without recreating the dashboard
* Format balance values using thousands separators and two decimal places

### Server API

* Add `SERVER.lookup.user.balance()` to the standardized lookup provider interface
* Implement balance lookup for the SQLite provider
* Support balance lookup using either:

  * Username
  * User UUID

### Database Schema

* Add a `BALANCE` column to the `USERS` table
* Set the default balance to `0.0` for newly created accounts

## Behavior

This change introduces balance presentation and refresh support only.

There are:

* No deposit, withdrawal, or transfer implementations
* No business logic changes to account operations
* No dashboard layout changes
* No authentication changes
* No API redesign beyond the addition of the balance lookup method

## Result

The dashboard now displays the authenticated user's current balance and exposes a reusable refresh interface for future balance-changing operations. The provider API now includes standardized balance retrieval, and newly created user accounts are initialized with a default balance.
