### PR TITLE
Generalize transaction lookup API with configurable limits

### DIFF
--- a/src/__server__/__base__/lookup.py
+++ b/src/__server__/__base__/lookup.py
@@ -23,7 +23,7 @@ class UserLookupBase(ABC):
 
     @classmethod
     @abstractmethod
-    def last_transaction(cls, username_or_uuid: str) -> tuple | None:
+    def transactions(cls, username_or_uuid: str, limit: int) -> list | None:
 
         pass
 

--- a/src/__server__/__base__/lookup.py
+++ b/src/__server__/__base__/lookup.py
@@ -23,7 +23,9 @@ class UserLookupBase(ABC):
 
     @classmethod
     @abstractmethod
-    def transactions(cls, username_or_uuid: str, limit: int) -> list | None:
+    def transactions(
+        cls, username_or_uuid: str, limit: int
+    ) -> list[tuple[str, float, str]]:
 
         pass
 

--- a/src/__server__/_sqlite3/lookup.py
+++ b/src/__server__/_sqlite3/lookup.py
@@ -73,7 +73,9 @@ class UserLookup(UserLookupBase):
         return row[0] if row is not None else None
 
     @classmethod
-    def last_transaction(cls, username_or_uuid: str) -> tuple | None:
+    def transactions(
+        cls, username_or_uuid: str, limit: int = 5
+    ) -> list[tuple[str, float, str]]:
         """(TRANSACTION_TYPE, AMOUNT, TIMESTAMP)"""
 
         user_uuid = (
@@ -84,7 +86,7 @@ class UserLookup(UserLookupBase):
 
         if not user_uuid:
 
-            return None
+            return []
 
         cursor.execute(
             """
@@ -95,12 +97,12 @@ class UserLookup(UserLookupBase):
             FROM TRANSACTIONS
             WHERE USER_UUID = ?
             ORDER BY TIMESTAMP DESC
-            LIMIT 1;
+            LIMIT ?;
             """,
-            (user_uuid,),
+            (user_uuid, limit),
         )
 
-        return cursor.fetchone()
+        return cursor.fetchall()
 
 
 class AdminLookup(AdminLookupBase):

--- a/src/dashboard/tiles/balance.py
+++ b/src/dashboard/tiles/balance.py
@@ -47,9 +47,11 @@ class balance:
 
     def set_balance_trend_icon(self) -> None:
 
-        last_transaction = SERVER.lookup.user.last_transaction(self.username)
+        last_transaction: tuple = SERVER.lookup.user.transactions(
+            self.username, limit=1
+        )[0]
 
-        if last_transaction is None:
+        if not last_transaction:
 
             self.balance_trend_icon.configure(
                 image=customtkinter.CTkImage(

--- a/src/dashboard/tiles/balance.py
+++ b/src/dashboard/tiles/balance.py
@@ -47,36 +47,26 @@ class balance:
 
     def set_balance_trend_icon(self) -> None:
 
-        last_transaction: tuple = SERVER.lookup.user.transactions(
-            self.username, limit=1
-        )[0]
+        transactions = SERVER.lookup.user.transactions(self.username, limit=1)
+
+        last_transaction = transactions[0] if transactions else None
 
         if not last_transaction:
 
-            self.balance_trend_icon.configure(
-                image=customtkinter.CTkImage(
-                    light_image=assets.icons.material.remove,
-                    dark_image=assets.icons.material.remove,
-                    size=(30, 30),
-                )
-            )
+            icon = assets.icons.material.remove
 
         elif last_transaction[0] in ("deposit", "transfer_in"):
 
-            self.balance_trend_icon.configure(
-                image=customtkinter.CTkImage(
-                    light_image=assets.icons.material.trending_up,
-                    dark_image=assets.icons.material.trending_up,
-                    size=(30, 30),
-                )
-            )
+            icon = assets.icons.material.trending_up
 
         else:
 
-            self.balance_trend_icon.configure(
-                image=customtkinter.CTkImage(
-                    light_image=assets.icons.material.trending_down,
-                    dark_image=assets.icons.material.trending_down,
-                    size=(30, 30),
-                )
+            icon = assets.icons.material.trending_down
+
+        self.balance_trend_icon.configure(
+            image=customtkinter.CTkImage(
+                light_image=icon,
+                dark_image=icon,
+                size=(30, 30),
             )
+        )


### PR DESCRIPTION
## Summary ( Closes #83 )

Refactor the transaction lookup system by replacing the single-result `last_transaction()` API with a generalized `transactions()` method that supports retrieving multiple recent transactions.

This change allows different dashboard components to request transaction history according to their requirements while keeping transaction retrieval logic centralized.

The Balance Trend indicator has been updated to use the new API while preserving its existing behavior.

## Changes

### Server Lookup API

Replace:

```python
SERVER.lookup.user.last_transaction(username)
```

with:

```python
SERVER.lookup.user.transactions(username, limit=1)
```

The new API:

* Accepts username or UUID identifiers
* Resolves usernames to internal UUIDs
* Retrieves recent transactions ordered by timestamp
* Supports configurable result limits

Examples:

```python
SERVER.lookup.user.transactions(username, limit=1)
```

```python
SERVER.lookup.user.transactions(username, limit=5)
```

### SQLite Provider Updates

Update the SQLite transaction lookup implementation:

* Replace `fetchone()` with `fetchall()`
* Add configurable SQL `LIMIT` parameter
* Return an empty list when no user or transactions are found

The returned structure remains:

```python
[
    (TRANSACTION_TYPE, AMOUNT, TIMESTAMP),
    ...
]
```

### Balance Trend Update

Update the balance trend indicator to use the generalized transaction API.

The tile now:

* Requests only the latest transaction using `limit=1`
* Handles empty transaction history safely
* Uses a shared icon assignment flow

Behavior remains unchanged:

* Deposit / transfer in → trending up
* Withdraw / transfer out → trending down
* No transactions → neutral icon

## Preserve Existing Behavior

This refactor only changes the transaction lookup interface.

There are:

* No database schema changes
* No transaction processing changes
* No dashboard layout changes
* No UI behavior changes

## Acceptance Criteria

* [x] `last_transaction()` removed
* [x] `transactions()` lookup method implemented
* [x] Configurable transaction limit supported
* [x] Existing balance trend functionality preserved
* [x] Empty transaction states handled correctly
* [x] Transaction retrieval remains ordered by latest timestamp

## Result

The transaction lookup API is now reusable for both single transaction checks and transaction history displays, providing a cleaner foundation for future dashboard components without duplicating database query logic.
