### PR TITLE
Implement Frequent Transfer Favorites in Dashboard

### DIFF
--- a/src/__server__/__base__/lookup.py
+++ b/src/__server__/__base__/lookup.py
@@ -42,6 +42,14 @@ class UserLookupBase(ABC):
 
         pass
 
+    @classmethod
+    @abstractmethod
+    def frequent_transfer_recipients(
+        cls, username_or_uuid: str
+    ) -> list[tuple[str, int]]:
+
+        pass
+
 
 class AdminLookupBase(ABC):
 

--- a/src/__server__/_sqlite3/lookup.py
+++ b/src/__server__/_sqlite3/lookup.py
@@ -128,6 +128,32 @@ class UserLookup(UserLookupBase):
             else None
         )
 
+    @classmethod
+    def frequent_transfer_recipients(
+        cls, username_or_uuid: str
+    ) -> list[tuple[str, int]]:
+
+        cursor.execute(
+            """
+            SELECT
+                COUNTERPARTY_USERNAME,
+                COUNT(*) AS TRANSFER_COUNT
+            FROM TRANSACTIONS
+            WHERE USER_UUID = (
+                SELECT UUID
+                FROM USERS
+                WHERE USERNAME = ? OR UUID = ?
+            )
+            AND TRANSACTION_TYPE = 'transfer_out'
+            GROUP BY COUNTERPARTY_USERNAME
+            ORDER BY TRANSFER_COUNT DESC
+            LIMIT 3
+            """,
+            (username_or_uuid, username_or_uuid),
+        )
+
+        return cursor.fetchall()
+
 
 class AdminLookup(AdminLookupBase):
 

--- a/src/dashboard/tiles/_favorites.py
+++ b/src/dashboard/tiles/_favorites.py
@@ -27,6 +27,24 @@ class favorites:
             )
             card.place(x=7, y=(7 + n * (64 + 7)))
 
+            customtkinter.CTkLabel(
+                card,
+                text=(recipient if len(recipient) < 25 else recipient[:21] + "..."),
+                width=231,
+                height=26,
+                font=("Consolas", 16, "bold"),
+                text_color="#D4D4D4",
+            ).place(x=0, y=6)
+
+            customtkinter.CTkLabel(
+                card,
+                text=f"{count} transfers",
+                width=231,
+                height=26,
+                font=("Consolas", 12),
+                text_color="#FFFFFF",
+            ).place(x=0, y=32)
+
     def refresh(self) -> None:
 
         widget: customtkinter.CTkFrame

--- a/src/dashboard/tiles/_favorites.py
+++ b/src/dashboard/tiles/_favorites.py
@@ -1,11 +1,28 @@
-from ... import customtkinter
+from ... import customtkinter, assets, SERVER
 
 
 class favorites:
 
     def __init__(self, parent_frame: customtkinter.CTkFrame, username: str) -> None:
 
+        self.username = username
+
         self.frame__favorites: customtkinter.CTkFrame = customtkinter.CTkFrame(
             parent_frame, width=245, height=220, fg_color="#0a0a0a"
         )
         self.frame__favorites.place(x=10, y=420)
+
+        self.load_favorites_cards()
+
+    def load_favorites_cards(self) -> None:
+
+        frequent_transfer_recipients: list[tuple[str, int]] = (
+            SERVER.lookup.user.frequent_transfer_recipients(self.username)
+        )
+
+        for n, (recipient, count) in enumerate(frequent_transfer_recipients):
+
+            card = customtkinter.CTkFrame(
+                self.frame__favorites, width=231, height=64, fg_color="#111111"
+            )
+            card.place(x=7, y=(7 + n * (64 + 7)))

--- a/src/dashboard/tiles/_favorites.py
+++ b/src/dashboard/tiles/_favorites.py
@@ -26,3 +26,13 @@ class favorites:
                 self.frame__favorites, width=231, height=64, fg_color="#111111"
             )
             card.place(x=7, y=(7 + n * (64 + 7)))
+
+    def refresh(self) -> None:
+
+        widget: customtkinter.CTkFrame
+
+        for widget in self.frame__favorites.winfo_children():
+
+            widget.destroy()
+
+        self.load_favorites_cards()


### PR DESCRIPTION
## Summary ( Closes #105 )

Implement a **Favorites** section within the dashboard to provide quick access to users who are frequently involved in transfers.

The Favorites tile displays the **top three most frequently transferred-to users**, retrieved dynamically from the database.

This implementation adds the required database lookup and renders the results as individual favorite cards within the existing Favorites tile.

## Objectives

### Fetch Frequent Transfer Recipients

Retrieve the users who appear most frequently as transfer recipients for the signed-in user.

The results should:

* Identify transfer recipients associated with the current user.
* Count the number of outgoing transfers to each recipient.
* Order recipients by transfer frequency in descending order.
* Return a maximum of three recipients.

### Integrate with Database Lookup

Add a standardized lookup API for retrieving frequent transfer recipients.

Example:

```python
SERVER.lookup.user.frequent_transfer_recipients(username_or_uuid)
```

The dashboard should access this information through the existing database abstraction rather than directly querying the database.

### Display Favorite Users

Render each frequent transfer recipient as a dedicated card within the existing Favorites tile.

Each card should display:

* Recipient username
* Number of transfers made to the recipient

If fewer than three eligible recipients exist, only the available recipients should be displayed.

If no transfer history exists, the Favorites tile should remain empty.

### Implement Favorites Refresh

Add a refresh mechanism that allows the Favorites tile to reload its contents from the database.

The refresh process should:

* Remove existing favorite cards.
* Retrieve the latest frequent transfer recipients.
* Recreate the displayed cards.

This allows the Favorites tile to reflect newly accumulated transfer history when refreshed.

## Preserve Existing Behavior

This issue focuses on retrieving and displaying frequent transfer recipients only.

There must be:

* No changes to transfer processing
* No changes to transaction creation logic
* No balance calculation changes
* No authentication changes
* No direct transfer execution from Favorites

## Acceptance Criteria

* [x] Frequent transfer recipient lookup added to the database abstraction
* [x] Top three recipients retrieved from the database
* [x] Recipients ranked by transfer frequency
* [x] Favorite recipients displayed as individual cards
* [x] Transfer count displayed for each recipient
* [x] Fewer than three recipients handled correctly
* [x] Favorites refresh mechanism implemented
* [x] Data retrieved through the database abstraction layer
* [x] Existing transfer and transaction behavior remains unchanged

## Out of Scope

* Executing transfers directly from Favorites
* Adding or removing favorites manually
* User-configurable favorite ordering
* Persistent favorites separate from transfer history
* More than three displayed favorites
* Favorite recipient search

## Result

After completion, the dashboard will dynamically display up to three users the signed-in user transfers to most frequently, along with their transfer counts. The Favorites tile can also be refreshed to reflect updated transfer activity, providing a foundation for future quick-transfer functionality.
