### PR TITLE
Fix transfer form state after completed transaction

### DIFF
--- a/src/dashboard/tiles/_actions/_transfer.py
+++ b/src/dashboard/tiles/_actions/_transfer.py
@@ -554,9 +554,14 @@ class transfer:
             self.__amount.delete(0, "end")
             self.__password.delete(0, "end")
             self.__username.delete(0, "end")
+
             self.balance_instance.refresh()
             self.favorites_instance.refresh()
             self.transactions_instance.refresh()
+
+            self.recipient_username = ""
+            self.validate_username_btn.place(x=302, y=342)
+            self.continue_to_if_01_transfer.place_forget()
             self.default_label_username_info.configure(
                 text="Enter a recipient username to continue."
             )


### PR DESCRIPTION
## Summary ( Closes #68 )

Fix a transfer form state issue that allowed a user to complete another transaction without entering a recipient username after a successful transfer.

## Changes

* Reset the recipient username state after a completed transfer.
* Restore the username validation button.
* Hide the transfer continuation button.
* Reset the username information prompt to its default state.
* Refresh the balance, favorites, and transactions tiles after the transaction completes.

## Result

After completing a transfer, the form is correctly reset and requires the user to enter and validate a recipient username before starting another transaction.
