### PR TITLE
Implement security overlay In User Dashboard

### DIFF
--- a/src/dashboard/overlays/_security.py
+++ b/src/dashboard/overlays/_security.py
@@ -1,12 +1,30 @@
-from ... import customtkinter, Callable
+from datetime import datetime, timezone
+from ... import customtkinter, Callable, SERVER
+
+EVENT_LABELS: dict[str, tuple[str, str]] = {
+    "login": (
+        "Logged in",
+        "[INFO]",
+    ),
+    "failed_login": (
+        "Failed login",
+        "[MEDIUM]",
+    ),
+    "logout": (
+        "Logged out",
+        "[INFO]",
+    ),
+}
 
 
 class security_overlay:
 
     def __init__(self, parent_frame: customtkinter.CTkFrame, username: str) -> None:
 
-        self.frame__security: customtkinter.CTkFrame = customtkinter.CTkFrame(
-            parent_frame, width=1080, height=590, fg_color="#0a0a0a"
+        self.username = username
+
+        self.frame__security: customtkinter.CTkScrollableFrame = customtkinter.CTkScrollableFrame(
+            parent_frame, width=1058, height=578, fg_color="#0a0a0a",
         )
 
         self.show_frame: Callable = lambda: (

--- a/src/dashboard/overlays/_security.py
+++ b/src/dashboard/overlays/_security.py
@@ -23,8 +23,13 @@ class security_overlay:
 
         self.username = username
 
-        self.frame__security: customtkinter.CTkScrollableFrame = customtkinter.CTkScrollableFrame(
-            parent_frame, width=1058, height=578, fg_color="#0a0a0a",
+        self.frame__security: customtkinter.CTkScrollableFrame = (
+            customtkinter.CTkScrollableFrame(
+                parent_frame,
+                width=1058,
+                height=578,
+                fg_color="#0a0a0a",
+            )
         )
 
         self.show_frame: Callable = lambda: (
@@ -34,24 +39,24 @@ class security_overlay:
         self.hide_frame: Callable = lambda: self.frame__security.place_forget()
 
     def load_security_cards(self) -> None:
-    
+
         total_security_events: list[tuple[str, str]] = (
             SERVER.lookup.security_event.recent(self.username, -1)
         )
 
         columns = 4
-        
+
         for column in range(columns):
-        
+
             self.frame__security.grid_columnconfigure(
                 column,
                 weight=1,
             )
-    
+
         for n, (event_type, timestamp) in enumerate(total_security_events):
-    
+
             get_event_labels = EVENT_LABELS.get(event_type, ("Unknown", "[INFO]"))
-    
+
             card = customtkinter.CTkFrame(
                 self.frame__security,
                 width=252,
@@ -69,7 +74,7 @@ class security_overlay:
                 pady=5,
                 sticky="nsew",
             )
-    
+
             customtkinter.CTkLabel(
                 card,
                 text=get_event_labels[0],
@@ -79,7 +84,7 @@ class security_overlay:
                 text_color="#D4D4D4",
                 anchor="w",
             ).place(x=6, y=0)
-    
+
             customtkinter.CTkLabel(
                 card,
                 text=get_event_labels[1],
@@ -89,7 +94,7 @@ class security_overlay:
                 text_color="#D4D4D4",
                 anchor="e",
             ).place(x=159, y=0)
-    
+
             customtkinter.CTkLabel(
                 card,
                 text=(
@@ -103,11 +108,11 @@ class security_overlay:
                 font=("Consolas", 10),
                 text_color="#A3A3A3",
             ).place(x=4, y=24)
-    
+
     def refresh(self) -> None:
-    
+
         for widget in self.frame__security.winfo_children():
-    
+
             widget.destroy()
-    
+
         self.load_security_cards()

--- a/src/dashboard/overlays/_security.py
+++ b/src/dashboard/overlays/_security.py
@@ -33,6 +33,81 @@ class security_overlay:
         )
         self.hide_frame: Callable = lambda: self.frame__security.place_forget()
 
-    def refresh(self) -> None:
+    def load_security_cards(self) -> None:
+    
+        total_security_events: list[tuple[str, str]] = (
+            SERVER.lookup.security_event.recent(self.username, -1)
+        )
 
-        pass
+        columns = 4
+        
+        for column in range(columns):
+        
+            self.frame__security.grid_columnconfigure(
+                column,
+                weight=1,
+            )
+    
+        for n, (event_type, timestamp) in enumerate(total_security_events):
+    
+            get_event_labels = EVENT_LABELS.get(event_type, ("Unknown", "[INFO]"))
+    
+            card = customtkinter.CTkFrame(
+                self.frame__security,
+                width=252,
+                height=38,
+                fg_color="#111111",
+            )
+
+            column = n % columns
+            row = n // columns
+
+            card.grid(
+                row=row,
+                column=column,
+                padx=5,
+                pady=5,
+                sticky="nsew",
+            )
+    
+            customtkinter.CTkLabel(
+                card,
+                text=get_event_labels[0],
+                width=153,
+                height=24,
+                font=("Consolas", 12, "bold"),
+                text_color="#D4D4D4",
+                anchor="w",
+            ).place(x=6, y=0)
+    
+            customtkinter.CTkLabel(
+                card,
+                text=get_event_labels[1],
+                width=89,
+                height=24,
+                font=("Consolas", 12, "bold"),
+                text_color="#D4D4D4",
+                anchor="e",
+            ).place(x=159, y=0)
+    
+            customtkinter.CTkLabel(
+                card,
+                text=(
+                    datetime.fromisoformat(timestamp)
+                    .replace(tzinfo=timezone.utc)
+                    .astimezone()
+                    .strftime("%Y-%m-%d %I:%M:%S %p (%z)")
+                ),  # %Y-%m-%d %I:%M:%S %p (%z)
+                width=244,
+                height=0,  # 12
+                font=("Consolas", 10),
+                text_color="#A3A3A3",
+            ).place(x=4, y=24)
+    
+    def refresh(self) -> None:
+    
+        for widget in self.frame__security.winfo_children():
+    
+            widget.destroy()
+    
+        self.load_security_cards()


### PR DESCRIPTION
## Summary ( Closes #125 )

Implement the **Security Overlay** for the dashboard to provide users with a scrollable view of their account security events.

## Changes

* Implemented the Security Overlay using a scrollable frame.
* Added security event mappings for:

  * Login
  * Failed login
  * Logout
* Added severity labels for displayed security events.
* Added security event cards arranged in a four-column grid.
* Added localized timestamp formatting for security events.
* Added fallback handling for unknown event types.
* Integrated the existing `SERVER.lookup.security_event.recent()` lookup API.
* Implemented `refresh()` to clear and reload security event cards.
* Added support for displaying the complete available security event history.

## Notes

* Security event data continues to be retrieved through the existing server lookup abstraction.
* No changes were made to authentication or security event recording logic.
* The overlay remains independently scrollable when the event history exceeds the available space.

## Testing

* Verified login, failed login, and logout events are displayed correctly.
* Verified security events are arranged in a four-column grid.
* Verified timestamps are converted to the local timezone.
* Verified unknown event types fall back gracefully.
* Verified refreshing the overlay clears previous cards and reloads the latest events.
